### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/jsonpointerx/json-pointer.ts
+++ b/src/jsonpointerx/json-pointer.ts
@@ -203,7 +203,7 @@ export class JsonPointer {
    * @returns {JsonPointer}
    */
   static compile(pointer: string, decodeOnly?: boolean): JsonPointer {
-    const segments = pointer.split('/').map((value) => this.isPrototypePolluted(value) ? '' : value )
+    const segments = pointer.split('/').map((value) => this.isPrototypePolluted(value) ? '' : value);
     const firstSegment = segments.shift();
     if (firstSegment === '') {
       return new JsonPointer(

--- a/src/jsonpointerx/json-pointer.ts
+++ b/src/jsonpointerx/json-pointer.ts
@@ -203,7 +203,7 @@ export class JsonPointer {
    * @returns {JsonPointer}
    */
   static compile(pointer: string, decodeOnly?: boolean): JsonPointer {
-    const segments = pointer.split('/').map((value) => this.isPrototypePolluted(value) ? '' : value);
+    const segments = pointer.split('/').map((value: string) => this.isPrototypePolluted(value) ? '' : value);
     const firstSegment = segments.shift();
     if (firstSegment === '') {
       return new JsonPointer(

--- a/src/jsonpointerx/json-pointer.ts
+++ b/src/jsonpointerx/json-pointer.ts
@@ -203,7 +203,7 @@ export class JsonPointer {
    * @returns {JsonPointer}
    */
   static compile(pointer: string, decodeOnly?: boolean): JsonPointer {
-    const segments = pointer.split('/');
+    const segments = pointer.split('/').map((value) => this.isPrototypePolluted(value) ? '' : value )
     const firstSegment = segments.shift();
     if (firstSegment === '') {
       return new JsonPointer(
@@ -279,5 +279,15 @@ export class JsonPointer {
     }
     /* istanbul ignore next */
     throw new Error('JsonPointer.unescapedReplacer: this should not happen');
+  }
+
+  /**
+   * Blacklist certain keys to prevent Prototype Pollution
+   * 
+   * @param key - The object key to check
+   * @returns boolean
+   */
+  private static isPrototypePolluted (key: any): boolean {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
   }
 }


### PR DESCRIPTION
### :bar_chart: Metadata *

`jsonpointerx` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-jsonpointerx

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var {JsonPointer} =require('jsonpointerx');
let obj = { };
let jp = JsonPointer.compile('/__proto__/polluted'); 
console.log("Before : " + {}.polluted);
jp.set(obj, 'Yes! Its Polluted'); 
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i jsonpointerx # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104120260-5ea60500-535b-11eb-8bee-08c978a765f0.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
